### PR TITLE
Fixed handler/stdout.py error under python3

### DIFF
--- a/django_actionlog/handler/stdout.py
+++ b/django_actionlog/handler/stdout.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 
-from __future__ import unicode_literals
+from __future__ import unicode_literals, print_function
 
 from . import handler_manager
 from . import log_format
@@ -16,12 +16,12 @@ class Stdout(object):
     def emit(self, messages):
         if not messages.get('is_middleware'):
             output = log_format.dict_to_str(messages)
-            print output
+            print(output)
         else:
             if 'ex_type' in messages:
                 output = log_format.error_log(messages)
             else:
                 output = log_format.standard_log(messages)
-            print output
+            print(output)
 
 handler_manager.register('stdout', Stdout)


### PR DESCRIPTION
Problem: stdout don't work with python3 because of print statement.