### PR TITLE
Add `REMOTE_ADDR` and `HTTP_USER_AGENT` to logging items

### DIFF
--- a/django_actionlog/handler/log_format.py
+++ b/django_actionlog/handler/log_format.py
@@ -13,6 +13,8 @@ OUTPUT_STANDARD = '================== Footprint Log ==================\n' \
                   'status_code : {}\n' \
                   'method      : {}\n' \
                   'user        : {}\n' \
+                  'remote_ip   : {}\n' \
+                  'user_agnet  : {}\n' \
                   'sql_count   : {}\n' \
                   'sql_time    : {}\n' \
                   'python_time : {}\n' \
@@ -26,6 +28,8 @@ OUTPUT_ERROR = '================== Footprint Log ==================\n' \
                'status_code : {}\n' \
                'method      : {}\n' \
                'user        : {}\n' \
+               'remote_ip   : {}\n' \
+               'user_agnet  : {}\n' \
                'ex_type     : {}\n' \
                'ex_message  : {}\n\n'
 
@@ -42,6 +46,8 @@ def standard_log(messages):
                                     messages['status_code'],
                                     messages['method'],
                                     messages['user'],
+                                    messages['remote_ip'],
+                                    messages['user_agent'],
                                     messages['sql_count'],
                                     messages['sql_time'],
                                     messages['python_time'],
@@ -56,6 +62,8 @@ def error_log(messages):
                                  messages['status_code'],
                                  messages['method'],
                                  messages['user'],
+                                 messages['remote_ip'],
+                                 messages['user_agent'],
                                  messages['ex_type'],
                                  messages['ex_message'])
     return output

--- a/django_actionlog/middleware.py
+++ b/django_actionlog/middleware.py
@@ -82,5 +82,7 @@ class ActionLogMiddleware(MiddlewareMixin):
                    'view_name': view_name,
                    'method': request.method,
                    'user': user_name,
+                   'remote_ip': request.META.get('REMOTE_ADDR', ''),
+                   'user_agent': request.META.get('HTTP_USER_AGENT', ''),
                    'total_time': round((time.time() - request.actionlog_start), 2)}
         return message


### PR DESCRIPTION
I recommend adding `REMOTE_ADDR` and `HTTP_USER_AGENT` to logging items.
`REMOTE_ADDR` and `HTTP_USER_AGENT` are useful when we analyze logs.